### PR TITLE
log_x(y)

### DIFF
--- a/dist/multiline.js
+++ b/dist/multiline.js
@@ -539,6 +539,7 @@ var defaultPresets = {
     e: Math.E,
     mod: [['x', 'y'], 'x-floor(x/y)*y'],
     tan: [['x'], 'sin(x)/cos(x)'],
+    logWithSubscript: [['x', 'y'], 'log(y)/log(x)'],
     cot: [['x'], 'cos(x)/sin(x)'],
     sec: [['x'], '1/cos(x)'],
     csc: [['x'], '1/sin(x)'],

--- a/dist/tex.js
+++ b/dist/tex.js
@@ -179,7 +179,19 @@ function convert(block) {
             continue;
         }
         var command = el.substring(1);
-        if (command === 'frac') {
+        if (command === 'log') {
+            if (elements[index] === '_') {
+                index++;
+                var sub = elements[index++];
+                if (!sub)
+                    throw 'Empty subscript after "log_"';
+                output.push(' ', 'logWithSubscript(', sub, ')');
+            }
+            else {
+                output.push(' ', 'log', ' ');
+            }
+        }
+        else if (command === 'frac') {
             var numerator = elements[index++];
             var denominator = elements[index++];
             if (!numerator || !denominator)

--- a/dist/tex.js
+++ b/dist/tex.js
@@ -179,19 +179,7 @@ function convert(block) {
             continue;
         }
         var command = el.substring(1);
-        if (command === 'log') {
-            if (elements[index] === '_') {
-                index++;
-                var sub = elements[index++];
-                if (!sub)
-                    throw 'Empty subscript after "log_"';
-                output.push(' ', 'logWithSubscript(', sub, ')');
-            }
-            else {
-                output.push(' ', 'log', ' ');
-            }
-        }
-        else if (command === 'frac') {
+        if (command === 'frac') {
             var numerator = elements[index++];
             var denominator = elements[index++];
             if (!numerator || !denominator)
@@ -206,7 +194,16 @@ function convert(block) {
             output.push(' ', name, ' ');
         }
         else if (functionCommands.has(command)) {
-            output.push(' ', command, ' ');
+            if (command === 'log' && elements[index] === '_') {
+                index++;
+                var sub = elements[index++];
+                if (!sub)
+                    throw "Empty subscript after \"" + command + "_\"";
+                output.push(' ', command + 'WithSubscript(', sub, ')');
+            }
+            else {
+                output.push(' ', command, ' ');
+            }
         }
         else {
             throw "Undefined command \"\\" + command + "\"";

--- a/src/multiline.ts
+++ b/src/multiline.ts
@@ -352,6 +352,7 @@ const defaultPresets: Presets = {
   e: Math.E,
   mod: [['x', 'y'], 'x-floor(x/y)*y'],
   tan: [['x'], 'sin(x)/cos(x)'],
+  logWithSubscript: [['x', 'y'], 'log(y)/log(x)'],
   cot: [['x'], 'cos(x)/sin(x)'],
   sec: [['x'], '1/cos(x)'],
   csc: [['x'], '1/sin(x)'],

--- a/src/parser_test.ts
+++ b/src/parser_test.ts
@@ -48,7 +48,11 @@ const examples: [string, string][] = [
   [
     'a/bc d + a/e(f+g) + a/sinxsiny + a/xsiny',
     'a/(b*c)*d + (a/e)*(f+g) + (a/sinx)*siny + (a/x)*siny'
-  ]
+  ],
+  [
+    'sin^2(x)',
+    '(sinx)^2'
+  ],
 ]
 
 function red(s: string) { return `\x1B[31m${s}\x1B[m`}

--- a/src/tex.ts
+++ b/src/tex.ts
@@ -160,7 +160,14 @@ function convert(block: Block): string {
       if (!name) throw 'Empty "\\operatorname{}"'
       output.push(' ', name, ' ')
     } else if (functionCommands.has(command)) {
-      output.push(' ', command, ' ')
+      if (command === 'log' && elements[index] === '_') {
+        index++
+        const sub = elements[index++]
+        if (!sub) throw `Empty subscript after "${command}_"`
+        output.push(' ', command + 'WithSubscript(', sub, ')')
+      } else {
+        output.push(' ', command, ' ')
+      }
     } else {
       throw `Undefined command "\\${command}"`
     }


### PR DESCRIPTION
`\log_{x}abc/d`
↓
`logWithSubscript(x, abc) / d`
...に変換するのは大変(どこまでがlogの引数か判断するのはparserの役割) なので
一度 `logWithSubscript(x)abc` に変換するようにした(`logWithSubscript(x)` 自体がdecorator付きのfunctionというような感じの扱い)

`\log_{x}^{y}\left(z\right)` ← これ試した時に sin^2(x)を sin^2(x) * (x) にparseしてるのに気づいてついでに直した