### PR TITLE
Parser alias fix, greek letter commands, refactor error messages

### DIFF
--- a/dist/multiline.js
+++ b/dist/multiline.js
@@ -81,10 +81,10 @@ function parseMultiple(formulaTexts, argNames, presets) {
         try {
             const [ast, mode] = parser_1.parse(body, new Set([...varNames, ...args]), funcNames);
             if (mode != null)
-                throw `invalid compare operator`;
+                throw `Unexpected compare operator`;
             const duplicateArgs = duplicates(args);
             if (duplicateArgs.length !== 0)
-                throw `duplicate argument name: ${JSON.stringify(duplicateArgs)}`;
+                throw `Duplicated argument name: ${JSON.stringify(duplicateArgs)}`;
             const variables = ast_1.extractVariables(ast).filter(n => !args.includes(n));
             const deps = [...variables, ...ast_1.extractFunctions(ast, funcNames)];
             definition = { type: 'func', name, deps, args, ast: uniq.convert(ast) };
@@ -377,6 +377,7 @@ function astToRangeFunctionCode(uniqAST, args, option) {
 exports.astToRangeFunctionCode = astToRangeFunctionCode;
 const defaultPresets = {
     pi: Math.PI,
+    'π': Math.PI,
     e: Math.E,
     mod: [['x', 'y'], 'x-floor(x/y)*y'],
     tan: [['x'], 'sin(x)/cos(x)'],
@@ -388,12 +389,17 @@ const defaultPresets = {
 };
 exports.presets2D = {
     r: 'hypot(x,y)',
-    theta: 'atan2(y,x)'
+    'θ': 'atan2(y,x)',
+    theta: 'θ',
+    th: 'θ',
 };
 exports.presets3D = {
     r: 'hypot(x,y,z)',
-    theta: 'atan2(y,x)',
-    phi: 'atan2(hypot(x,y),z)',
+    'θ': 'atan2(y,x)',
+    theta: 'θ',
+    th: 'θ',
+    φ: 'atan2(hypot(x,y),z)',
+    phi: 'φ',
 };
 function duplicates(elements) {
     const dups = new Set();

--- a/dist/tex.js
+++ b/dist/tex.js
@@ -6,21 +6,52 @@ function texToPlain(s) {
 }
 exports.texToPlain = texToPlain;
 const commandAlias = {
-    'gt': '>',
-    'ge': '≥',
-    'geq': '≥',
-    'geqq': '≥',
-    'le': '≤',
-    'leq': '≤',
-    'leqq': '≤',
-    'lt': '<',
-    'pi': 'π',
-    'theta': 'θ',
-    'phi': 'φ',
-    'cdot': '・',
-    'times': '×',
-    'div': '÷',
+    gt: '>',
+    ge: '≥',
+    geq: '≥',
+    geqq: '≥',
+    le: '≤',
+    leq: '≤',
+    leqq: '≤',
+    lt: '<',
+    cdot: '・',
+    times: '×',
+    div: '÷',
 };
+const greekLetters = [
+    'alpha',
+    'beta',
+    'gamma',
+    'delta',
+    'epsilon',
+    'zeta',
+    'eta',
+    'theta',
+    'iota',
+    'kappa',
+    'lambda',
+    'mu',
+    'nu',
+    'xi',
+    'omicron',
+    'pi',
+    'rho',
+    'sigma',
+    'tau',
+    'upsilon',
+    'phi',
+    'chi',
+    'psi',
+    'omega',
+];
+greekLetters.forEach((name, i) => {
+    const code = 913 + (i < 17 ? i : i + 1);
+    const aw = String.fromCharCode(code + 32);
+    const AW = String.fromCharCode(code);
+    const Name = name[0].toUpperCase() + name.substring(1);
+    commandAlias[name] = aw;
+    commandAlias[Name] = AW;
+});
 const functionCommands = new Set([
     'sqrt', 'log', 'exp',
     'sin', 'cos', 'tan',
@@ -52,7 +83,7 @@ function parse(s) {
         const last = stack.pop();
         current = stack[stack.length - 1];
         if (last == null || current == null || last.type !== type || last.command !== command)
-            throw 'Paren mismatch';
+            throw 'Parentheses mismatch';
     }
     while (index < chars.length) {
         const c = chars[index++];
@@ -73,7 +104,7 @@ function parse(s) {
                     open('paren', true);
                 }
                 else {
-                    throw `Unsupported paren "${k}"`;
+                    throw `Unsupported bracket type "${k}"`;
                 }
             }
             else if (cmd === 'right' || cmd === 'mright') {
@@ -85,7 +116,7 @@ function parse(s) {
                     close('paren', true);
                 }
                 else {
-                    throw `Unsupported paren "${k}"`;
+                    throw `Unsupported bracket type "${k}"`;
                 }
             }
             else {
@@ -114,7 +145,7 @@ function parse(s) {
         }
     }
     if (stack.length !== 1)
-        throw 'Too few paren';
+        throw 'Too few parentheses';
     return stack[0].children;
 }
 function convert(block) {

--- a/src/multiline.ts
+++ b/src/multiline.ts
@@ -349,6 +349,7 @@ export function astToRangeFunctionCode(uniqAST: UniqASTNode, args: string[], opt
 
 const defaultPresets: Presets = {
   pi: Math.PI,
+  'π': Math.PI,
   e: Math.E,
   mod: [['x', 'y'], 'x-floor(x/y)*y'],
   tan: [['x'], 'sin(x)/cos(x)'],
@@ -361,12 +362,17 @@ const defaultPresets: Presets = {
 
 export const presets2D: Presets = {
   r: 'hypot(x,y)',
-  theta: 'atan2(y,x)'
+  'θ': 'atan2(y,x)',
+  theta: 'θ',
+  th: 'θ',
 }
 export const presets3D: Presets = {
   r: 'hypot(x,y,z)',
-  theta: 'atan2(y,x)',
-  phi: 'atan2(hypot(x,y),z)',
+  'θ': 'atan2(y,x)',
+  theta: 'θ',
+  th: 'θ',
+  φ: 'atan2(hypot(x,y),z)',
+  phi: 'φ',
 }
 
 function duplicates<T>(elements: T[]): T[] {

--- a/src/multiline.ts
+++ b/src/multiline.ts
@@ -77,9 +77,9 @@ export function parseMultiple(formulaTexts: string[], argNames: string[], preset
     let definition: FuncDef
     try {
       const [ast, mode] = parse(body, new Set([...varNames, ...args]), funcNames)
-      if (mode != null) throw `invalid compare operator`
+      if (mode != null) throw `Unexpected compare operator`
       const duplicateArgs = duplicates(args)
-      if (duplicateArgs.length !== 0) throw `duplicate argument name: ${JSON.stringify(duplicateArgs)}`
+      if (duplicateArgs.length !== 0) throw `Duplicated argument name: ${JSON.stringify(duplicateArgs)}`
       const variables = extractVariables(ast).filter(n => !args.includes(n))
       const deps = [...variables, ...extractFunctions(ast, funcNames)]
       definition = { type: 'func', name, deps, args, ast: uniq.convert(ast) }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -12,7 +12,6 @@ const alias: Record<string, string | undefined> = {
   '・': '*', '×': '*', '÷': '/', '**': '^', '√': 'sqrt',
   'arcsin': 'asin', 'arccos': 'acos', 'arctan': 'atan',
   'arctanh': 'atanh', 'arccosh': 'acosh', 'arcsinh': 'asinh',
-  'π': 'pi', 'th': 'theta', 'θ': 'theta', 'φ': 'phi',
   'sgn': 'sign', 'signum': 'sign', 'factorial': 'fact',
 }
 const tokenSet = new Set([...predefinedFunctionNames, ...Object.keys(alias), ...operators, ...comparers, ',', ' '])

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -27,8 +27,8 @@ function parseParen(input: string): ParenGroup {
   }
   const pop = (abs: boolean) => {
     const last = stack.pop()!
-    if (last.abs !== abs) throw 'Absolute Paren Mismatch'
-    if (stack.length === 0) throw 'Paren Mismatch'
+    if (last.abs !== abs) throw 'Absolute value brackets mismatch'
+    if (stack.length === 0) throw 'Parentheses mismatch'
     current = stack[stack.length - 1]
   }
   for (const c of input) {
@@ -47,7 +47,7 @@ function parseParen(input: string): ParenGroup {
       current.group.push(c)
     }
   }
-  if (stack.length !== 1) throw 'Paren Mismatch'
+  if (stack.length !== 1) throw 'Parentheses mismatch'
   return current.group
 }
 
@@ -81,10 +81,17 @@ function tokenize(group: ParenGroup, tokens: Tokens): TokenParenGroup {
     const item = group[i]
     if (item === ' ') {
       if (out[out.length - 1] !== item) out.push(item)
-      i += 1
+      i ++
     } else if (typeof item === 'string') {
       const result = matchToken(pattern, i, tokens)
-      if (!result) throw `Unexpected Token "${pattern[i]}"`
+      if (!result) {
+        const s = pattern[i]
+        if (s.match(/[a-zA-Zα-ωΑ-Ω]+/)) {
+          throw `Undefined variable or function name "${s}"`
+        } else {
+          throw `Unexpected token "${s}"`
+        }
+      }
       const [v, len] = result
       out.push(v)
       i += len
@@ -176,8 +183,8 @@ type Node = string | number | Args | Paren
 type Consumer = { [key in keyof ParseStateData]: (node: Node | null, ...args: ParseStateData[key]) => ParseState }
 function assertIndependentNode<T>(node: T, functionNames?: Set<string>): T {
   if (typeof node === 'string') {
-    if (node === '!' || node === '^') throw 'Unexpected operator. Wrap with paren.'
-    if (functionNames && functionNames.has(node)) throw 'Unexpected function. Wrap with paren.'
+    if (node === '!' || node === '^') throw 'Unexpected operator. Wrap with parentheses.'
+    if (functionNames && functionNames.has(node)) throw 'Unexpected function. Wrap with parentheses.'
   }
   return node
 }
@@ -316,7 +323,7 @@ function buildFuncMultPowBang(group: TokenParenGroup, functionNames: Set<string>
     'func ^ ex'(node, func, decorators, ex) {
       if (node == null) throw 'Unexpected end of input after func^ex. expected arguments'
       if (node === ' ') return ['func ^ ex', func, decorators, ex]
-      if (typeof node !== 'object') throw 'Wrap function args with paren'
+      if (typeof node !== 'object') throw 'Wrap function arguments with parentheses'
       const funcCall = { op: func, args: node.type === 'args' ? [...decorators, ...node.value] : [...decorators, node.value] }
       multGroups.push({ op: '^', args: [funcCall, ex] })
       return ['default']
@@ -368,25 +375,25 @@ function splitByOp<T extends string>(items: TokenParenGroup, op: T[]) {
 
 function splitMultDiv(group: TokenParenGroup, functionNames: Set<string>): ASTNode {
   const result = splitByOp(group, ['*', '/']).reduce((ast, [op, group]) => {
-    if (group.length === 0) throw `No Right Hand Side: ${op}`
-    if (ast == null && op != null) throw `No Left Hand Side: ${op}`
+    if (group.length === 0) throw `No right hand side: ${op}`
+    if (ast == null && op != null) throw `No left hand side: ${op}`
     const nodes = buildFuncMultPowBang(group, functionNames)
     if (op === '/') ast = { op: '/', args: [ast!, nodes.shift()!] }
     const rhs = nodes.length ? nodes.reduce((a, b) => ({ op: '*', args: [a, b] })) : null
     if (ast != null && rhs != null) return { op: '*', args: [ast, rhs] }
     return ast ?? rhs
   }, null as null | ASTNode)
-  if (result == null) throw 'Unexpected Empty Group'
+  if (result == null) throw 'Unexpected empty group'
   return result
 }
 function splitPlusMinus(group: TokenParenGroup, functionNames: Set<string>): ASTNode {
   const result = splitByOp(group, ['+', '-']).reduce((ast, [op, group]) => {
-    if (group.length === 0) throw `No Right Hand Side: ${op}`
+    if (group.length === 0) throw `No right hand side: ${op}`
     const rhs = splitMultDiv(group, functionNames)
     if (ast === null) return op === '-' ? { op: '-@', args: [rhs] } : rhs
     return { op: op === '-' ? '-' : '+', args: [ast, rhs] }
   }, null as null | ASTNode)
-  if (result == null) throw 'Unexpected Empty Group'
+  if (result == null) throw 'Unexpected empty group'
   return result
 }
 

--- a/src/tex.ts
+++ b/src/tex.ts
@@ -20,21 +20,54 @@ type BlockGroup = {
 }
 type Group = ParenGroup | AbsGroup | BlockGroup 
 const commandAlias: Record<string, string> = {
-  'gt': '>',
-  'ge': '≥',
-  'geq': '≥',
-  'geqq': '≥',
-  'le': '≤',
-  'leq': '≤',
-  'leqq': '≤',
-  'lt': '<',
-  'pi': 'π',
-  'theta': 'θ',
-  'phi': 'φ',
-  'cdot': '・',
-  'times': '×',
-  'div': '÷',
+  gt: '>',
+  ge: '≥',
+  geq: '≥',
+  geqq: '≥',
+  le: '≤',
+  leq: '≤',
+  leqq: '≤',
+  lt: '<',
+  cdot: '・',
+  times: '×',
+  div: '÷',
 }
+
+const greekLetters = [
+  'alpha',
+  'beta',
+  'gamma',
+  'delta',
+  'epsilon',
+  'zeta',
+  'eta',
+  'theta',
+  'iota',
+  'kappa',
+  'lambda',
+  'mu',
+  'nu',
+  'xi',
+  'omicron',
+  'pi',
+  'rho',
+  'sigma',
+  'tau',
+  'upsilon',
+  'phi',
+  'chi',
+  'psi',
+  'omega',
+]
+greekLetters.forEach((name, i) => {
+  const code = 913 + (i < 17 ? i : i + 1)
+  const aw = String.fromCharCode(code + 32)
+  const AW = String.fromCharCode(code)
+  const Name = name[0].toUpperCase() + name.substring(1)
+  commandAlias[name] = aw
+  commandAlias[Name] = AW
+})
+
 const functionCommands = new Set([
   'sqrt', 'log', 'exp',
   'sin', 'cos', 'tan',

--- a/src/tex.ts
+++ b/src/tex.ts
@@ -97,7 +97,7 @@ function parse(s: string): Block {
   function close(type: Group['type'], command: boolean) {
     const last = stack.pop()
     current = stack[stack.length - 1]
-    if (last == null || current == null || last.type !== type || last.command !== command) throw 'Paren mismatch'
+    if (last == null || current == null || last.type !== type || last.command !== command) throw 'Parentheses mismatch'
   }
   while (index < chars.length) {
     const c = chars[index++]
@@ -114,7 +114,7 @@ function parse(s: string): Block {
         } else if (k === '(') {
           open('paren', true)
         } else {
-          throw `Unsupported paren "${k}"`
+          throw `Unsupported bracket type "${k}"`
         }
       } else if (cmd === 'right' || cmd === 'mright') {
         const k = chars[index++]
@@ -123,7 +123,7 @@ function parse(s: string): Block {
         } else if (k === ')') {
           close('paren', true)
         } else {
-          throw `Unsupported paren "${k}"`
+          throw `Unsupported bracket type "${k}"`
         }
       } else {
         current.children.push(commandAlias[cmd] ?? '\\' + cmd)
@@ -145,7 +145,7 @@ function parse(s: string): Block {
       current.children.push(c)
     }
   }
-  if (stack.length !== 1) throw 'Too few paren'
+  if (stack.length !== 1) throw 'Too few parentheses'
   return stack[0].children
 }
 


### PR DESCRIPTION
`θ=1` が等式`arctan(y,x)=1`じゃなく `変数 θ = 1`の定義になってしまう・そう定義してるのに`sinθ`が`sin(arctan(y,x))`のままになる問題修正
θにtheta thと別名がついてるけど関数登録されてるのが一つだけだった・parser側でが何故かthetaとpiのaliasを定義してたのがそもそもの問題だった

ついでにtexのギリシャ文字全部使えるように・エラーメッセージ変なところ直した